### PR TITLE
hotfix missing original entity

### DIFF
--- a/src/Listener/MutationListener.php
+++ b/src/Listener/MutationListener.php
@@ -44,7 +44,7 @@ class MutationListener
 
         $strategy = $annotation->getStrategy();
 
-        if ($strategy === Mutation::STRATEGY_COPY_PREVIOUS && $em->getUnitOfWork()->isScheduledForInsert($entity)) {
+        if ($strategy === Mutation::STRATEGY_COPY_PREVIOUS && null === $event->getOriginalEntity()) {
             return;
         }
 

--- a/test/Listener/MutationListenerTest.php
+++ b/test/Listener/MutationListenerTest.php
@@ -72,22 +72,6 @@ class MutationListenerTest extends \PHPUnit_Framework_TestCase
             ->method('persist')
             ->with($this->isInstanceOf(get_class($current_entity) . 'Mutation'));
 
-        $uow = $this
-            ->getMockBuilder('Doctrine\ORM\UnitOfWork')
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $uow
-            ->expects($this->once())
-            ->method('isScheduledForInsert')
-            ->with($current_entity)
-            ->willReturn(false);
-
-        $this->em
-            ->expects($this->once())
-            ->method('getUnitOfWork')
-            ->willReturn($uow);
-
         $event = new EntityChangedEvent($this->em, $current_entity, $original_entity, $mutated_fields);
         $this->listener->entityChanged($event);
 
@@ -209,22 +193,6 @@ class MutationListenerTest extends \PHPUnit_Framework_TestCase
             ->method('getMutationAnnotation')
             ->with($this->em, $current_entity)
             ->willReturn($annotation);
-
-        $uow = $this
-            ->getMockBuilder('Doctrine\ORM\UnitOfWork')
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $uow
-            ->expects($this->once())
-            ->method('isScheduledForInsert')
-            ->with($current_entity)
-            ->willReturn(true);
-
-        $this->em
-            ->expects($this->once())
-            ->method('getUnitOfWork')
-            ->willReturn($uow);
 
         $this->em
             ->expects($this->never())


### PR DESCRIPTION
Since new entities are send from the `PrePersist` event, the
unit of work no longer marks them as scheduled for insert. Checking
the original for `null` will provide you with the same information
in a much more elegant way and fixes the problem of having no
original when using the `STRATEGY_COPY_PREVIOUS`.