### PR TITLE
Attribute support, drop PHP<8.3 support

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -8,7 +8,7 @@ jobs:
 
         strategy:
             matrix:
-                php-versions: ['7.3', '7.4', '8.0']
+                php-versions: ['8.3', '8.4']
         name: PHP ${{ matrix.php-versions }}
         steps:
             -   uses: actions/checkout@v2

--- a/composer.json
+++ b/composer.json
@@ -6,13 +6,13 @@
     "require": {
         "php":                              "^8.3",
         "doctrine/orm":                     "^2.7.4",
-        "hostnet/entity-tracker-component": "^2.0.1"
+        "hostnet/entity-tracker-component": "^2.3.0"
     },
     "require-dev": {
         "hostnet/database-test-lib": "^2.0.2",
         "hostnet/phpcs-tool":        "^9.1.0",
         "phpunit/phpunit":           "^9.5.6",
-        "symfony/cache":             "^5.3"
+        "symfony/cache":             "^6.4|^7.4"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "license":           "MIT",
     "minimum-stability": "stable",
     "require": {
-        "php":                              "^7.3||^8.0",
+        "php":                              "^8.3",
         "doctrine/orm":                     "^2.7.4",
         "hostnet/entity-tracker-component": "^2.0.1"
     },

--- a/src/Attributes/Mutation.php
+++ b/src/Attributes/Mutation.php
@@ -1,48 +1,38 @@
 <?php
 /**
- * @copyright 2016-present Hostnet B.V.
+ * @copyright 2026-present Hostnet B.V.
  */
 declare(strict_types=1);
 
-namespace Hostnet\Component\EntityMutation;
+namespace Hostnet\Component\EntityMutation\Attributes;
 
-use Hostnet\Component\EntityTracker\Annotation\Tracked;
+use Hostnet\Component\EntityTracker\Attributes\Tracked;
 
-/**
- * @Annotation
- * @Target({"CLASS"})
- *
- * @deprecated Please use the attribute instead.
- */
+#[\Attribute(\Attribute::TARGET_CLASS)]
 class Mutation extends Tracked
 {
-    /**
-     * The Previous values will be stored in the mutation table. This is the
-     * default strategy.
-     */
+    public function __construct(
+        public string $strategy = self::STRATEGY_COPY_PREVIOUS,
+    ) {
+    }
+        /**
+         * The Previous values will be stored in the mutation table. This is the
+         * default strategy.
+         */
     public const STRATEGY_COPY_PREVIOUS = 'previous';
 
     /**
-     * The Previous values will be stored in the mutation table. And the
+     * The current values will be stored in the mutation table. And the
      * mutation will also be added on creation of the entity.
      */
     public const STRATEGY_COPY_CURRENT = 'current';
-
-    public $class = '';
-
-    /**
-     * @Enum({"previous", "current"})
-     */
-    public $strategy = self::STRATEGY_COPY_PREVIOUS;
 
     /**
      * Get the strategy for storing the mutation data.
      *
      * @return Mutation::STRATEGY_COPY_PREVIOUS|Mutation::STRATEGY_COPY_CURRENT
-     *
-     * @deprecated Please use the attribute instead.
      */
-    public function getStrategy()
+    public function getStrategy(): string
     {
         if (!in_array($this->strategy, [self::STRATEGY_COPY_PREVIOUS, self::STRATEGY_COPY_CURRENT], true)) {
             throw new \RuntimeException(

--- a/src/Attributes/Mutation.php
+++ b/src/Attributes/Mutation.php
@@ -19,13 +19,13 @@ class Mutation extends Tracked
          * The Previous values will be stored in the mutation table. This is the
          * default strategy.
          */
-    public const STRATEGY_COPY_PREVIOUS = 'previous';
+    public const string STRATEGY_COPY_PREVIOUS = 'previous';
 
     /**
      * The current values will be stored in the mutation table. And the
      * mutation will also be added on creation of the entity.
      */
-    public const STRATEGY_COPY_CURRENT = 'current';
+    public const string STRATEGY_COPY_CURRENT = 'current';
 
     /**
      * Get the strategy for storing the mutation data.

--- a/src/Listener/MutationListener.php
+++ b/src/Listener/MutationListener.php
@@ -6,7 +6,7 @@ declare(strict_types=1);
 
 namespace Hostnet\Component\EntityMutation\Listener;
 
-use Hostnet\Component\EntityMutation\Mutation;
+use Hostnet\Component\EntityMutation\Attributes\Mutation;
 use Hostnet\Component\EntityMutation\MutationAwareInterface;
 use Hostnet\Component\EntityMutation\Resolver\MutationResolverInterface;
 use Hostnet\Component\EntityTracker\Event\EntityChangedEvent;
@@ -19,6 +19,11 @@ class MutationListener
     private $resolver;
 
     /**
+     * Caches the class names to prevent iterating over attribute and annotations again on the next entity.
+     */
+    private array $is_mutation_cache = [];
+
+    /**
      * @param MutationResolverInterface $resolver
      */
     public function __construct(MutationResolverInterface $resolver)
@@ -29,12 +34,12 @@ class MutationListener
     /**
      * @param EntityChangedEvent $event
      */
-    public function entityChanged(EntityChangedEvent $event)
+    public function entityChanged(EntityChangedEvent $event): void
     {
         $em     = $event->getEntityManager();
         $entity = $event->getCurrentEntity();
 
-        if (null === ($annotation = $this->resolver->getMutationAnnotation($em, $entity))) {
+        if (false === $strategy = $this->getMutationStrategy($em, $entity)) {
             return;
         }
 
@@ -43,8 +48,6 @@ class MutationListener
         if (empty($fields)) {
             return;
         }
-
-        $strategy = $annotation->getStrategy();
 
         if ($strategy === Mutation::STRATEGY_COPY_PREVIOUS && null === $event->getOriginalEntity()) {
             return;
@@ -71,5 +74,43 @@ class MutationListener
         if ($entity instanceof MutationAwareInterface) {
             $entity->addMutation($mutation);
         }
+    }
+
+    private function getMutationStrategy($em, $entity): false|string
+    {
+        $class = get_class($entity);
+        if (array_key_exists($class, $this->is_mutation_cache)) {
+            return $this->is_mutation_cache[$class];
+        }
+
+        if (null !== $annotation = $this->resolver->getMutationAnnotation($em, $entity)) {
+            $this->is_mutation_cache[$class] = $annotation->getStrategy();
+
+            return $this->is_mutation_cache[$class];
+        }
+
+        if (null !== $strategy = $this->getMutationAttributeStrategy($entity)) {
+            $this->is_mutation_cache[$class] = $strategy;
+
+            return $this->is_mutation_cache[$class];
+        }
+
+        $this->is_mutation_cache[$class] = false;
+
+        return false;
+    }
+
+    private function getMutationAttributeStrategy($entity): ?string
+    {
+        $reflection = new \ReflectionClass($entity);
+        $attributes = $reflection->getAttributes(Mutation::class);
+
+        if (empty($attributes)) {
+            return null;
+        }
+
+        /** @var Mutation $attribute */
+        $attribute = $attributes[0]->newInstance();
+        return $attribute->getStrategy();
     }
 }

--- a/src/Listener/MutationListener.php
+++ b/src/Listener/MutationListener.php
@@ -10,25 +10,19 @@ use Hostnet\Component\EntityMutation\Attributes\Mutation;
 use Hostnet\Component\EntityMutation\MutationAwareInterface;
 use Hostnet\Component\EntityMutation\Resolver\MutationResolverInterface;
 use Hostnet\Component\EntityTracker\Event\EntityChangedEvent;
+use Psr\Cache\CacheItemInterface;
+use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
 
 class MutationListener
 {
     /**
-     * @var MutationResolverInterface
-     */
-    private $resolver;
-
-    /**
-     * Caches the class names to prevent iterating over attribute and annotations again on the next entity.
-     */
-    private array $is_mutation_cache = [];
-
-    /**
      * @param MutationResolverInterface $resolver
      */
-    public function __construct(MutationResolverInterface $resolver)
-    {
-        $this->resolver = $resolver;
+    public function __construct(
+        private MutationResolverInterface $resolver,
+        private CacheItemPoolInterface $is_mutation_cache = new ArrayAdapter()
+    ) {
     }
 
     /**
@@ -78,39 +72,29 @@ class MutationListener
 
     private function getMutationStrategy($em, $entity): false|string
     {
-        $class = get_class($entity);
-        if (array_key_exists($class, $this->is_mutation_cache)) {
-            return $this->is_mutation_cache[$class];
+        $cache_key   = base64_encode('MUTATION-' . get_class($entity));
+        $cached_item = $this->is_mutation_cache->getItem($cache_key);
+
+        if ($cached_item->isHit()) {
+            return $cached_item->get();
+        }
+
+        if (null !== $attribute = $this->resolver->getMutationAttribute($em, $entity)) {
+            return $this->save($cached_item, $attribute->getStrategy());
         }
 
         if (null !== $annotation = $this->resolver->getMutationAnnotation($em, $entity)) {
-            $this->is_mutation_cache[$class] = $annotation->getStrategy();
-
-            return $this->is_mutation_cache[$class];
+            return $this->save($cached_item, $annotation->getStrategy());
         }
 
-        if (null !== $strategy = $this->getMutationAttributeStrategy($entity)) {
-            $this->is_mutation_cache[$class] = $strategy;
-
-            return $this->is_mutation_cache[$class];
-        }
-
-        $this->is_mutation_cache[$class] = false;
-
-        return false;
+        return $this->save($cached_item, false);
     }
 
-    private function getMutationAttributeStrategy($entity): ?string
+    private function save(CacheItemInterface $item, false|string $value): false|string
     {
-        $reflection = new \ReflectionClass($entity);
-        $attributes = $reflection->getAttributes(Mutation::class);
+        $item->set($value);
+        $this->is_mutation_cache->save($item);
 
-        if (empty($attributes)) {
-            return null;
-        }
-
-        /** @var Mutation $attribute */
-        $attribute = $attributes[0]->newInstance();
-        return $attribute->getStrategy();
+        return $value;
     }
 }

--- a/src/Mutation.php
+++ b/src/Mutation.php
@@ -20,14 +20,17 @@ class Mutation extends Tracked
      * The Previous values will be stored in the mutation table. This is the
      * default strategy.
      */
-    public const STRATEGY_COPY_PREVIOUS = 'previous';
+    public const string STRATEGY_COPY_PREVIOUS = 'previous';
 
     /**
      * The Previous values will be stored in the mutation table. And the
      * mutation will also be added on creation of the entity.
      */
-    public const STRATEGY_COPY_CURRENT = 'current';
+    public const string STRATEGY_COPY_CURRENT = 'current';
 
+    /**
+     * @deprecated Not supported by the attribute
+     */
     public $class = '';
 
     /**

--- a/src/MutationAwareInterface.php
+++ b/src/MutationAwareInterface.php
@@ -6,6 +6,9 @@ declare(strict_types=1);
 
 namespace Hostnet\Component\EntityMutation;
 
+/**
+ * TODO: add typehints on next BC break, removing doctrine/annotations
+ */
 interface MutationAwareInterface
 {
     /**

--- a/src/Resolver/MutationResolver.php
+++ b/src/Resolver/MutationResolver.php
@@ -33,7 +33,7 @@ class MutationResolver implements MutationResolverInterface
     /**
      * {@inheritdoc}
      */
-    public function getMutationAnnotation(EntityManagerInterface $em, $entity)
+    public function getMutationAnnotation(EntityManagerInterface $em, $entity): ?Mutation
     {
         return $this->provider->getAnnotationFromEntity($em, $entity, $this->annotation);
     }
@@ -41,7 +41,7 @@ class MutationResolver implements MutationResolverInterface
     /**
      * {@inheritdoc}
      */
-    public function getMutationClassName(EntityManagerInterface $em, $entity)
+    public function getMutationClassName(EntityManagerInterface $em, $entity): ?string
     {
         if (null === ($annotation = $this->getMutationAnnotation($em, $entity))) {
             return null;
@@ -53,7 +53,7 @@ class MutationResolver implements MutationResolverInterface
     /**
      * {@inheritdoc}
      */
-    public function getMutatableFields(EntityManagerInterface $em, $entity)
+    public function getMutatableFields(EntityManagerInterface $em, $entity): array
     {
         $mutation_class = $this->getMutationClassName($em, $entity);
         $metadata       = $em->getClassMetadata(get_class($entity));

--- a/src/Resolver/MutationResolver.php
+++ b/src/Resolver/MutationResolver.php
@@ -9,7 +9,7 @@ namespace Hostnet\Component\EntityMutation\Resolver;
 use Doctrine\ORM\EntityManagerInterface;
 use Hostnet\Component\EntityMutation\Attributes\Mutation;
 use Hostnet\Component\EntityMutation\Mutation as MutationAnnotation;
-use Hostnet\Component\EntityTracker\Provider\EntityAnnotationMetadataProvider;
+use Hostnet\Component\EntityTracker\Provider\EntityMetadataProvider;
 
 class MutationResolver implements MutationResolverInterface
 {
@@ -18,17 +18,8 @@ class MutationResolver implements MutationResolverInterface
      */
     private $annotation = MutationAnnotation::class;
 
-    /**
-     * @var EntityAnnotationMetadataProvider
-     */
-    private $provider;
-
-    /**
-     * @param EntityAnnotationMetadataProvider $provider
-     */
-    public function __construct(EntityAnnotationMetadataProvider $provider)
+    public function __construct(private EntityMetadataProvider $provider)
     {
-        $this->provider = $provider;
     }
 
     /**

--- a/src/Resolver/MutationResolver.php
+++ b/src/Resolver/MutationResolver.php
@@ -7,7 +7,8 @@ declare(strict_types=1);
 namespace Hostnet\Component\EntityMutation\Resolver;
 
 use Doctrine\ORM\EntityManagerInterface;
-use Hostnet\Component\EntityMutation\Mutation;
+use Hostnet\Component\EntityMutation\Attributes\Mutation;
+use Hostnet\Component\EntityMutation\Mutation as MutationAnnotation;
 use Hostnet\Component\EntityTracker\Provider\EntityAnnotationMetadataProvider;
 
 class MutationResolver implements MutationResolverInterface
@@ -15,7 +16,7 @@ class MutationResolver implements MutationResolverInterface
     /**
      * @var string
      */
-    private $annotation = Mutation::class;
+    private $annotation = MutationAnnotation::class;
 
     /**
      * @var EntityAnnotationMetadataProvider
@@ -33,18 +34,25 @@ class MutationResolver implements MutationResolverInterface
     /**
      * {@inheritdoc}
      */
-    public function getMutationAnnotation(EntityManagerInterface $em, $entity): ?Mutation
+    public function getMutationAnnotation(EntityManagerInterface $em, $entity): ?MutationAnnotation
     {
         return $this->provider->getAnnotationFromEntity($em, $entity, $this->annotation);
+    }
+
+    public function getMutationAttribute(EntityManagerInterface $em, $entity): ?Mutation
+    {
+        return $this->provider->getAttributeFromEntity(Mutation::class, $em, $entity);
     }
 
     /**
      * {@inheritdoc}
      */
-    public function getMutationClassName(EntityManagerInterface $em, $entity): ?string
+    public function getMutationClassName(EntityManagerInterface $em, $entity): string
     {
-        if (null === ($annotation = $this->getMutationAnnotation($em, $entity))) {
-            return null;
+        $annotation = $this->getMutationAnnotation($em, $entity);
+        // If $annotation is null, we must be using the attribute, otherwise this code would not get hit.
+        if (null === $annotation) {
+            return get_class($entity) . 'Mutation';
         }
 
         return !empty($annotation->class) ? $annotation->class : get_class($entity) . 'Mutation';

--- a/src/Resolver/MutationResolverInterface.php
+++ b/src/Resolver/MutationResolverInterface.php
@@ -7,7 +7,8 @@ declare(strict_types=1);
 namespace Hostnet\Component\EntityMutation\Resolver;
 
 use Doctrine\ORM\EntityManagerInterface;
-use Hostnet\Component\EntityMutation\Mutation;
+use Hostnet\Component\EntityMutation\Attributes\Mutation;
+use Hostnet\Component\EntityMutation\Mutation as MutationAnnotation;
 
 interface MutationResolverInterface
 {
@@ -17,12 +18,14 @@ interface MutationResolverInterface
      *
      * @deprecated Please use the attribute instead.
      */
-    public function getMutationAnnotation(EntityManagerInterface $em, $entity): ?Mutation;
+    public function getMutationAnnotation(EntityManagerInterface $em, $entity): ?MutationAnnotation;
+
+    public function getMutationAttribute(EntityManagerInterface $em, $entity): ?Mutation;
 
     /**
      * Return the mutation class name
      */
-    public function getMutationClassName(EntityManagerInterface $em, $entity): ?string;
+    public function getMutationClassName(EntityManagerInterface $em, $entity): string;
 
     /**
      * Return list of mutatable fields

--- a/src/Resolver/MutationResolverInterface.php
+++ b/src/Resolver/MutationResolverInterface.php
@@ -14,21 +14,20 @@ interface MutationResolverInterface
     /**
      * Return the mutation annotation
      *
-     * @return Mutation
+     *
+     * @deprecated Please use the attribute instead.
      */
-    public function getMutationAnnotation(EntityManagerInterface $em, $entity);
+    public function getMutationAnnotation(EntityManagerInterface $em, $entity): ?Mutation;
 
     /**
      * Return the mutation class name
-     *
-     * @return string
      */
-    public function getMutationClassName(EntityManagerInterface $em, $entity);
+    public function getMutationClassName(EntityManagerInterface $em, $entity): ?string;
 
     /**
      * Return list of mutatable fields
      *
      * @return string[]
      */
-    public function getMutatableFields(EntityManagerInterface $em, $entity);
+    public function getMutatableFields(EntityManagerInterface $em, $entity): array;
 }

--- a/test/Attributes/MutationTest.php
+++ b/test/Attributes/MutationTest.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * @copyright 2014-present Hostnet B.V.
+ */
+declare(strict_types=1);
+
+namespace Hostnet\Component\EntityMutation\Attributes;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Hostnet\Component\EntityMutation\Attributes\Mutation
+ */
+class MutationTest extends TestCase
+{
+    public function testGetStrategy(): void
+    {
+        $mutation = new Mutation();
+        $this->assertEquals(Mutation::STRATEGY_COPY_PREVIOUS, $mutation->getStrategy());
+        $mutation->strategy = Mutation::STRATEGY_COPY_CURRENT;
+        $this->assertEquals(Mutation::STRATEGY_COPY_CURRENT, $mutation->getStrategy());
+    }
+
+    /**
+     * @dataProvider getStrategyExceptionProvider
+     * @param mixed $strategy
+     */
+    public function testGetStrategyException($strategy): void
+    {
+        $mutation           = new Mutation();
+        $mutation->strategy = $strategy;
+        $this->expectException(\RuntimeException::class);
+        $mutation->getStrategy();
+    }
+
+    public function getStrategyExceptionProvider(): iterable
+    {
+        return [
+            [''],
+            ['test'],
+            ['last'],
+            ['before'],
+        ];
+    }
+}

--- a/test/Listener/MutationListenerTest.php
+++ b/test/Listener/MutationListenerTest.php
@@ -8,11 +8,12 @@ namespace Hostnet\Component\EntityMutation\Listener;
 
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\Persistence\Mapping\ClassMetadata;
+use Hostnet\Component\EntityMutation\Attributes\Mutation;
 use Hostnet\Component\EntityMutation\Mocked\MockMutationEntity;
 use Hostnet\Component\EntityMutation\Mocked\MockMutationEntityAttribute;
 use Hostnet\Component\EntityMutation\Mocked\MockMutationEntityAttributeMutation;
 use Hostnet\Component\EntityMutation\Mocked\MockMutationEntityMutation;
-use Hostnet\Component\EntityMutation\Mutation;
+use Hostnet\Component\EntityMutation\Mutation as MutationAnnotation;
 use Hostnet\Component\EntityMutation\Resolver\MutationResolverInterface;
 use Hostnet\Component\EntityTracker\Event\EntityChangedEvent;
 use PHPUnit\Framework\TestCase;
@@ -52,7 +53,7 @@ class MutationListenerTest extends TestCase
             ->with($this->em, $current_entity)
             ->willReturn(['id']);
 
-        $annotation = new Mutation();
+        $annotation = new MutationAnnotation();
 
         $this->resolver
             ->expects($this->once())
@@ -105,8 +106,8 @@ class MutationListenerTest extends TestCase
             ->with($this->em, $current_entity)
             ->willReturn(['id']);
 
-        $annotation           = new Mutation();
-        $annotation->strategy = Mutation::STRATEGY_COPY_CURRENT;
+        $annotation           = new MutationAnnotation();
+        $annotation->strategy = MutationAnnotation::STRATEGY_COPY_CURRENT;
 
         $this->resolver
             ->expects($this->once())
@@ -226,8 +227,8 @@ class MutationListenerTest extends TestCase
             ->with($this->em, $current_entity)
             ->willReturn([]);
 
-        $annotation           = new Mutation();
-        $annotation->strategy = Mutation::STRATEGY_COPY_CURRENT;
+        $annotation           = new MutationAnnotation();
+        $annotation->strategy = MutationAnnotation::STRATEGY_COPY_CURRENT;
 
         $this->resolver
             ->expects($this->once())
@@ -290,9 +291,9 @@ class MutationListenerTest extends TestCase
 
         $this->resolver
             ->expects($this->once())
-            ->method('getMutationAnnotation')
+            ->method('getMutationAttribute')
             ->with($this->em, $current_entity)
-            ->willReturn(null);
+            ->willReturn(new Mutation());
 
         $this->resolver
             ->expects($this->exactly(2))

--- a/test/Listener/MutationListenerTest.php
+++ b/test/Listener/MutationListenerTest.php
@@ -9,6 +9,8 @@ namespace Hostnet\Component\EntityMutation\Listener;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\Persistence\Mapping\ClassMetadata;
 use Hostnet\Component\EntityMutation\Mocked\MockMutationEntity;
+use Hostnet\Component\EntityMutation\Mocked\MockMutationEntityAttribute;
+use Hostnet\Component\EntityMutation\Mocked\MockMutationEntityAttributeMutation;
 use Hostnet\Component\EntityMutation\Mocked\MockMutationEntityMutation;
 use Hostnet\Component\EntityMutation\Mutation;
 use Hostnet\Component\EntityMutation\Resolver\MutationResolverInterface;
@@ -268,5 +270,58 @@ class MutationListenerTest extends TestCase
         $this->listener->entityChanged($event);
 
         $this->assertCount(0, $current_entity->getMutations());
+    }
+
+    public function testOnEntityChangedWithAttribute(): void
+    {
+        $current_entity  = new MockMutationEntityAttribute();
+        $original_entity = new MockMutationEntityAttribute();
+
+        $current_entity->id  = 2;
+        $original_entity->id = 1;
+
+        $mutated_fields = ['id'];
+
+        $this->resolver
+            ->expects($this->exactly(2))
+            ->method('getMutatableFields')
+            ->with($this->em, $current_entity)
+            ->willReturn(['id']);
+
+        $this->resolver
+            ->expects($this->once())
+            ->method('getMutationAnnotation')
+            ->with($this->em, $current_entity)
+            ->willReturn(null);
+
+        $this->resolver
+            ->expects($this->exactly(2))
+            ->method('getMutationClassName')
+            ->with($this->em, $current_entity)
+            ->willReturn(get_class($current_entity) . 'Mutation');
+
+        $mutation_meta = $this->createMock(ClassMetadata::class);
+        $mutation_meta
+            ->expects($this->any())
+            ->method('getReflectionClass')
+            ->willReturn(new \ReflectionClass(get_class($current_entity) . 'Mutation'));
+
+        $this->em
+            ->expects($this->exactly(2))
+            ->method('getClassMetadata')
+            ->with(get_class($current_entity) . 'Mutation')
+            ->willReturn($mutation_meta);
+
+        $this->em
+            ->expects($this->exactly(2))
+            ->method('persist')
+            ->with($this->isInstanceOf(get_class($current_entity) . 'Mutation'));
+
+        $event = new EntityChangedEvent($this->em, $current_entity, $original_entity, $mutated_fields);
+        $this->listener->entityChanged($event);
+
+        $this->assertTrue(current($current_entity->getMutations()) instanceof MockMutationEntityAttributeMutation);
+
+        $this->listener->entityChanged($event); // covers getting the attribute from the cache, submits a 2nd mutation.
     }
 }

--- a/test/Mocked/MockMutationEntityAttribute.php
+++ b/test/Mocked/MockMutationEntityAttribute.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * @copyright 2014-present Hostnet B.V.
+ */
+declare(strict_types=1);
+
+namespace Hostnet\Component\EntityMutation\Mocked;
+
+use Hostnet\Component\EntityMutation\Attributes\Mutation;
+use Hostnet\Component\EntityMutation\MutationAwareInterface;
+
+#[Mutation(strategy: Mutation::STRATEGY_COPY_CURRENT)]
+class MockMutationEntityAttribute implements MutationAwareInterface
+{
+    /**
+     * @ORM\Id
+     * @ORM\GeneratedValue
+     * @ORM\Column(name="id",type="integer")
+     */
+    public $id;
+
+    /**
+     * @ORM\ManyToOne(targetEntity="MockEntity", inversedBy="mutations")
+     * @ORM\JoinColumn(name="id", referencedColumnName="id")
+     */
+    public $mutations = [];
+
+    /**
+     * @ORM\OneToOne(targetEntity="MockEntity")
+     * @ORM\JoinColumn(name="parent", referencedColumnName="id")
+     * @var unknown
+     */
+    public $parent;
+
+    /**
+     * @see \Hostnet\Component\EntityMutation\MutationAwareInterface::addMutation()
+     */
+    public function addMutation($mutation): void
+    {
+        $this->mutations[] = $mutation;
+    }
+
+    /**
+     * @see \Hostnet\Component\EntityMutation\MutationAwareInterface::getMutations()
+     */
+    public function getMutations()
+    {
+        return $this->mutations;
+    }
+
+    /**
+     * @see \Hostnet\Component\EntityMutation\MutationAwareInterface::getPreviousMutation()
+     */
+    public function getPreviousMutation()
+    {
+        return current($this->mutations) ?: null;
+    }
+}

--- a/test/Mocked/MockMutationEntityAttributeMutation.php
+++ b/test/Mocked/MockMutationEntityAttributeMutation.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * @copyright 2016-present Hostnet B.V.
+ */
+declare(strict_types=1);
+
+namespace Hostnet\Component\EntityMutation\Mocked;
+
+class MockMutationEntityAttributeMutation
+{
+    public function __construct(MockMutationEntityAttribute $e, MockMutationEntityAttribute $original_data)
+    {
+    }
+}

--- a/test/Resolver/MutationResolverTest.php
+++ b/test/Resolver/MutationResolverTest.php
@@ -8,7 +8,8 @@ namespace Hostnet\Component\EntityMutation\Resolver;
 
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\Persistence\Mapping\ClassMetadata;
-use Hostnet\Component\EntityMutation\Mutation;
+use Hostnet\Component\EntityMutation\Attributes\Mutation;
+use Hostnet\Component\EntityMutation\Mutation as MutationAnnotation;
 use Hostnet\Component\EntityTracker\Provider\EntityAnnotationMetadataProvider;
 use PHPUnit\Framework\TestCase;
 
@@ -43,7 +44,7 @@ class MutationResolverTest extends TestCase
         $this->provider
             ->expects($this->once())
             ->method('getAnnotationFromEntity')
-            ->with($this->em, $entity, Mutation::class);
+            ->with($this->em, $entity, MutationAnnotation::class);
 
         $this->resolver->getMutationAnnotation($this->em, $entity);
     }
@@ -51,16 +52,18 @@ class MutationResolverTest extends TestCase
     public function testGetMutationClassName(): void
     {
         $entity            = new \stdClass();
-        $annotation        = new Mutation();
+        $annotation        = new MutationAnnotation();
         $annotation->class = 'Phpunit';
 
         $this->provider
             ->expects($this->exactly(3))
             ->method('getAnnotationFromEntity')
             ->with($this->em, $entity, 'Hostnet\Component\EntityMutation\Mutation')
-            ->willReturnOnConsecutiveCalls(null, new Mutation(), $annotation);
+            ->willReturnOnConsecutiveCalls(null, new MutationAnnotation(), $annotation);
 
-        $this->assertEquals('', $this->resolver->getMutationClassName($this->em, $entity));
+        // Without annotation, assuming the attribute is in use
+        $this->assertEquals('stdClassMutation', $this->resolver->getMutationClassName($this->em, $entity));
+
         $this->assertEquals('stdClassMutation', $this->resolver->getMutationClassName($this->em, $entity));
         $this->assertEquals('Phpunit', $this->resolver->getMutationClassName($this->em, $entity));
     }
@@ -74,7 +77,7 @@ class MutationResolverTest extends TestCase
         $this->provider
             ->expects($this->once())
             ->method('getAnnotationFromEntity')
-            ->willReturnOnConsecutiveCalls(new Mutation());
+            ->willReturnOnConsecutiveCalls(new MutationAnnotation());
 
         $metadata->expects($this->once())->method('getFieldNames')->willReturn(['id']);
         $metadata_meta->expects($this->once())->method('getFieldNames')->willReturn(['id']);
@@ -88,5 +91,20 @@ class MutationResolverTest extends TestCase
             ->willReturnOnConsecutiveCalls($metadata, $metadata_meta);
 
         $this->assertEquals(['id', 'test'], $this->resolver->getMutatableFields($this->em, $entity));
+    }
+
+    public function testGetMutationAttribute(): void
+    {
+        $entity = new \stdClass();
+
+        $attribute = new Mutation(Mutation::STRATEGY_COPY_CURRENT);
+
+        $this->provider
+            ->expects($this->once())
+            ->method('getAttributeFromEntity')
+            ->with(Mutation::class, $this->em, $entity)
+            ->willReturn($attribute);
+
+        self::assertSame($attribute, $this->resolver->getMutationAttribute($this->em, $entity));
     }
 }


### PR DESCRIPTION
- Adds support for attributes, deprecating annotations
- Drops PHP<8.3 support 
- Needs https://github.com/hostnet/entity-tracker-component/pull/45